### PR TITLE
Ajout d'un tl;dr legal

### DIFF
--- a/front/src/features/landingPage/css/landingPage.css
+++ b/front/src/features/landingPage/css/landingPage.css
@@ -10,7 +10,7 @@ html {
     height: 100%;
 }
 
-body,
+
 h1,
 h2,
 h3,
@@ -19,6 +19,10 @@ h5,
 h6 {
     font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-weight: 700;
+}
+
+body {
+    font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .topnav {

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -157,7 +157,7 @@
             <a
                 ng-class="['btn', 'btn-default', 'btn-lg', 'btn-primary', 'tokenAction',
                 {disabled: !check}]"
-                href="mailto:apiparticulier@sgmap.fr">
+                href="mailto:apiparticulier@sgmap.fr?subject=Demande d'accès à API Particulier&amp;body=Bonjour, je suis intéressé par API Particulier. Veuillez me recontacter aux <Coordonnées>. Merci">
               Demandez un jeton
             </a>
           </div>

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -65,6 +65,83 @@
           </a>
         </div>
       </div>
+      <div class="row">
+        <div class="col-md-12">
+          <p class="lead">
+            La charte peut être synthétisée sous la forme d'un tableau vous
+            expliquant vos droits, devoirs et interdits.
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4">
+          <ul class="list-group">
+            <li href="" class="list-group-item list-group-item-success">
+              Les droits
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Afficher les données brutes à l'agent instructeur</h4>
+              <p class="list-group-item-text">
+                L'agent du service instructeur, étant assermenté, peut voir les
+                informations personnelles
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Afficher les données après traitement à l'usager</h4>
+              <p class="list-group-item-text">
+                Il est possible d'afficher des données si elles ont été modifiées,
+                par exemple, les tarifs de la cantine après avoir été calculés à
+                partir du quotient familial récupéré auprès de la CAF
+              </p>
+            </li>
+          </ul>
+        </div>
+
+        <div class="col-md-4">
+          <ul class="list-group">
+            <li href="" class="list-group-item list-group-item-info">
+              Les devoirs
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Accepter de la charte</h4>
+              <p class="list-group-item-text">
+                Il n'est pas nécessaire de la faire signer. Récupérer le token
+                vous engage à respecter la charte
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Récupérer l'accord de l'usager</h4>
+              <p class="list-group-item-text">Explicitement demander l'accord de
+                l'usager pour récupérer ses données auprès d'un fournisseur</p>
+            </li>
+          </ul>
+        </div>
+
+        <div class="col-md-4">
+          <ul class="list-group">
+            <li href="" class="list-group-item list-group-item-danger">
+              Les interdits
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Afficher les données brutes à l'usager</h4>
+              <p class="list-group-item-text">
+                API Particulier ne permet pas d'identier la personne, on n'affiche
+                pas d'informations personnelles à l'usager car il peut s'agir
+                des données d'un autre
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Recupérer les informations par "batch"</h4>
+              <p class="list-group-item-text">
+                Ne pouvant pas récupérer l'accord explicite de l'usager, il est
+                impossible de lancer des récupérations de données en masse par des
+                traitements non lancés par l'usager.
+              </p>
+            </li>
+          </ul>
+        </div>
+
+      </div>
       <form>
         <div class="row">
           <div class="col-md-10 col-md-offset-1">


### PR DESCRIPTION
Ajout d'une traduction de la charte en se basant sur [tldrlegal](https://www.tldrlegal.com/l/apache2)

Le rendu ressemble à ça ?
![charte](https://cloud.githubusercontent.com/assets/5861569/12888391/297178da-ce7a-11e5-9b72-60cbe2ba7193.png)

Vous pouvez vous rendre sur la [page d'inscription](https://apiparticulier-dev.sgmap.fr/#/registration) pour voir le rendu complet. 

Vous en pensez quoi ?