### PR TITLE
Ajout d'un tl;dr legal 2

### DIFF
--- a/front/src/features/landingPage/css/landingPage.css
+++ b/front/src/features/landingPage/css/landingPage.css
@@ -17,12 +17,12 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-weight: 700;
 }
 
 body {
-    font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .topnav {

--- a/front/src/features/landingPage/css/landingPage.css
+++ b/front/src/features/landingPage/css/landingPage.css
@@ -10,7 +10,7 @@ html {
     height: 100%;
 }
 
-body,
+
 h1,
 h2,
 h3,
@@ -19,6 +19,10 @@ h5,
 h6 {
     font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-weight: 700;
+}
+
+body {
+    font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .topnav {

--- a/front/src/features/landingPage/landingPage.html
+++ b/front/src/features/landingPage/landingPage.html
@@ -12,7 +12,7 @@
                 </button>
                 <ul class="nav navbar-nav">
                   <li><img class="logo" src="img/logo_marianne.png" alt="Accueil - apiparticulier.sgmap.fr"></li>
-                  <li><a ui-sref="landingPage" class="navbar-brand title" title="Accueil - apiparticulier.sgmap.fr" href="/">API PARTICULIER</a></li>
+                  <li><a ui-sref="landingPage" class="navbar-brand title" title="Accueil - apiparticulier.sgmap.fr" href="/">API Particulier</a></li>
                 </ul>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
@@ -48,7 +48,7 @@
             <div class="row">
                 <div class="col-lg-12">
                     <div class="intro-message">
-                        <h1>API PARTICULIER</h1>
+                        <h1>API Particulier</h1>
                         <h3>Simplifiez vos démarches, ne demandez plus de
                           justificatifs</h3>
                         <hr class="intro-divider">
@@ -151,14 +151,14 @@
                     </p>
 
                     <p class="lead">
-                      API PARTICULIER, quant à lui, propose une solution non
+                      API Particulier, quant à lui, propose une solution non
                       identifiée&#160;: pour l'utilisateur qui n'a pas de compte,
                       pour les données liées au foyer familial et non à la
                       personne…
                     </p>
 
                     <p class="lead">
-                      API PARTICULIER et France connect peuvent être utilisés
+                      API Particulier et France connect peuvent être utilisés
                       seuls ou en parallèle.
                     </p>
                 </div>
@@ -181,7 +181,7 @@
             <div class="row">
               <div class="col-lg-12">
                 <h2 class="section-heading">
-                  Exemples d'utilisation d'API PARTICULIER
+                  Exemples d'utilisation d'API Particulier
                 </h2>
               </div>
             </div>

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -72,17 +72,19 @@
               <h3>Vous pouvez : </h3>
             </li>
             <li class="list-group-item">
+              <h4 class="list-group-item-heading">Récupérer les données nécessaires à vos démarches</h4>
+              <p class="list-group-item-text">
+                Vous récupérez des données fiables que vous pouvez facilement intégrer
+                dans vos procesus d'instruction.
+              </p>
+            </li>
+            <li class="list-group-item">
               <h4 class="list-group-item-heading">Afficher des données retravaillées à l’usager</h4>
               <p class="list-group-item-text">
                 Il est possible d'afficher des données à l’usager, si elles ne
                 menacent pas sa vie privée par exemple, les tarifs de la cantine
                 après avoir été calculés à partir du quotient familial récupéré
                 auprès de la CAF.
-              </p>
-            </li>
-            <li class="list-group-item">
-              <h4 class="list-group-item-heading"> Inventer des services innovants avec l’API</h4>
-              <p class="list-group-item-text">
               </p>
             </li>
           </ul>

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -157,7 +157,7 @@
             <a
                 ng-class="['btn', 'btn-default', 'btn-lg', 'btn-primary', 'tokenAction',
                 {disabled: !check}]"
-                href="mailto:apiparticulier@sgmap.fr">
+                href="mailto:apiparticulier@sgmap.fr?subject=Demande d'accès à API Particulier&amp;body=Bonjour, je suis intéressé par API Particulier. Veuillez me recontacter aux <Coordonnées>. Merci">
               Demandez un jeton
             </a>
           </div>

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -69,7 +69,7 @@
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-success">
-              <h3>Vous pouvez : </h3>
+              <h3>Vous pouvez :</h3>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Récupérer les données nécessaires à vos démarches</h4>
@@ -81,8 +81,8 @@
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Afficher des données retravaillées à l’usager</h4>
               <p class="list-group-item-text">
-                Il est possible d'afficher des données à l’usager, si elles ne
-                menacent pas sa vie privée par exemple, les tarifs de la cantine
+                Il est possible d'afficher des données à l’usager si elles ne
+                menacent pas sa vie privée. Par exemple, les tarifs de la cantine
                 après avoir été calculés à partir du quotient familial récupéré
                 auprès de la CAF.
               </p>
@@ -93,7 +93,7 @@
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-info">
-              <h3>Vous devez : </h3>
+              <h3>Vous devez :</h3>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Accepter la charte</h4>
@@ -106,7 +106,7 @@
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Traiter la bonne donnée par le bon agent</h4>
               <p class="list-group-item-text">L'agent habilité du service
-                instructeur peut accéder aux données personnelles
+                instructeur peut accéder aux données personnelles.
               </p>
             </li>
             <li class="list-group-item">
@@ -124,7 +124,7 @@
               <h3>Vous ne pouvez pas :</h3>
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading"> Afficher des données confidentielles à l’usager</h4>
+              <h4 class="list-group-item-heading">Afficher des données confidentielles à l’usager</h4>
               <p class="list-group-item-text">
                 L’usager n’étant pas authentifié, aucune garantie ne vous permet
                 d’afficher des donnée liées à la vie privée sans prendre le

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -12,7 +12,7 @@
                 </button>
                 <ul class="nav navbar-nav">
                   <li><img class="logo" src="img/logo_marianne.png" alt="Accueil - apiparticulier.sgmap.fr"></li>
-                  <li><a ui-sref="landingPage" class="navbar-brand title" title="Accueil - apiparticulier.sgmap.fr" href="/">API PARTICULIER</a></li>
+                  <li><a ui-sref="landingPage" class="navbar-brand title" title="Accueil - apiparticulier.sgmap.fr" href="/">API Particulier</a></li>
                 </ul>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
@@ -60,24 +60,21 @@
       </div>
       <div class="row">
         <div class="col-md-10 col-md-offset-1 text-right">
-          <a href="/charte.pdf" download="[Charte] API PARTICULIER.pdf">
+          <a href="/charte.pdf" download="[Charte] API Particulier.pdf">
             Télécharger la charte
           </a>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <p class="lead">
-            La charte peut être synthétisée sous la forme d'un tableau vous
-            expliquant vos droits, devoirs et interdits.
-          </p>
+          <h3>Vos droits et devoirs à l'utilisation d'API Particulier</h3>
         </div>
       </div>
       <div class="row">
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-success">
-              Les droits
+              Vos droits
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Afficher les données brutes à l'agent instructeur</h4>
@@ -100,19 +97,20 @@
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-info">
-              Les devoirs
+              Vos devoirs
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading">Accepter de la charte</h4>
+              <h4 class="list-group-item-heading">Accepter la charte</h4>
               <p class="list-group-item-text">
-                Il n'est pas nécessaire de la faire signer. Récupérer le token
-                vous engage à respecter la charte
+                Il n'est pas nécessaire de la faire signer. Obtenir le jeton
+                vous engage à respecter la charte.
               </p>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Récupérer l'accord de l'usager</h4>
               <p class="list-group-item-text">Explicitement demander l'accord de
-                l'usager pour récupérer ses données auprès d'un fournisseur</p>
+                l'usager pour récupérer ses données auprès d'un fournisseur.
+              </p>
             </li>
           </ul>
         </div>
@@ -125,13 +123,13 @@
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Afficher les données brutes à l'usager</h4>
               <p class="list-group-item-text">
-                API Particulier ne permet pas d'identier la personne, on n'affiche
+                API Particulier ne permet pas d'identifier la personne, vous n'afficherez
                 pas d'informations personnelles à l'usager car il peut s'agir
-                des données d'un autre
+                des données d'un autre.
               </p>
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading">Recupérer les informations par "batch"</h4>
+              <h4 class="list-group-item-heading">Recupérer les informations par lot</h4>
               <p class="list-group-item-text">
                 Ne pouvant pas récupérer l'accord explicite de l'usager, il est
                 impossible de lancer des récupérations de données en masse par des
@@ -146,8 +144,8 @@
         <div class="row">
           <div class="col-md-10 col-md-offset-1">
             <label class="checkDroits">
-              <input type="checkbox" ng-model="check"> J'ai compris les
-              modalités d'utilisation et d'intégration d'API PARTICULIER
+              <input type="checkbox" ng-model="check"> J'ai compris et j'accepte
+              les modalités d'utilisation et d'intégration d'API Particulier
             </label>
           </div>
         </div>
@@ -157,7 +155,7 @@
             <a
                 ng-class="['btn', 'btn-default', 'btn-lg', 'btn-primary', 'tokenAction',
                 {disabled: !check}]"
-                href="mailto:apiparticulier@sgmap.fr?subject=Demande d'accès à API Particulier&amp;body=Bonjour, je suis intéressé par API Particulier. Veuillez me recontacter aux <Coordonnées>. Merci">
+                href="mailto:apiparticulier@sgmap.fr?subject=Demande d'accès à API Particulier">
               Demandez un jeton
             </a>
           </div>

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -66,15 +66,10 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-md-12">
-          <h3>Vos droits et devoirs à l'utilisation d'API Particulier</h3>
-        </div>
-      </div>
-      <div class="row">
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-success">
-              Vos droits
+              <h3>Vous pouvez : </h3>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Afficher des données retravaillées à l’usager</h4>
@@ -96,7 +91,7 @@
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-info">
-              Vos devoirs
+              <h3>Vous devez : </h3>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Accepter la charte</h4>
@@ -124,7 +119,7 @@
         <div class="col-md-4">
           <ul class="list-group">
             <li href="" class="list-group-item list-group-item-danger">
-              Les interdits
+              <h3>Vous ne pouvez pas :</h3>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading"> Afficher des données confidentielles à l’usager</h4>

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -65,6 +65,83 @@
           </a>
         </div>
       </div>
+      <div class="row">
+        <div class="col-md-12">
+          <p class="lead">
+            La charte peut être synthétisée sous la forme d'un tableau vous
+            expliquant vos droits, devoirs et interdits.
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4">
+          <ul class="list-group">
+            <li href="" class="list-group-item list-group-item-success">
+              Les droits
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Afficher les données brutes à l'agent instructeur</h4>
+              <p class="list-group-item-text">
+                L'agent du service instructeur, étant assermenté, peut voir les
+                informations personnelles
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Afficher les données après traitement à l'usager</h4>
+              <p class="list-group-item-text">
+                Il est possible d'afficher des données si elles ont été modifiées,
+                par exemple, les tarifs de la cantine après avoir été calculés à
+                partir du quotient familial récupéré auprès de la CAF
+              </p>
+            </li>
+          </ul>
+        </div>
+
+        <div class="col-md-4">
+          <ul class="list-group">
+            <li href="" class="list-group-item list-group-item-info">
+              Les devoirs
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Accepter de la charte</h4>
+              <p class="list-group-item-text">
+                Il n'est pas nécessaire de la faire signer. Récupérer le token
+                vous engage à respecter la charte
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Récupérer l'accord de l'usager</h4>
+              <p class="list-group-item-text">Explicitement demander l'accord de
+                l'usager pour récupérer ses données auprès d'un fournisseur</p>
+            </li>
+          </ul>
+        </div>
+
+        <div class="col-md-4">
+          <ul class="list-group">
+            <li href="" class="list-group-item list-group-item-danger">
+              Les interdits
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Afficher les données brutes à l'usager</h4>
+              <p class="list-group-item-text">
+                API Particulier ne permet pas d'identier la personne, on n'affiche
+                pas d'informations personnelles à l'usager car il peut s'agir
+                des données d'un autre
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Recupérer les informations par "batch"</h4>
+              <p class="list-group-item-text">
+                Ne pouvant pas récupérer l'accord explicite de l'usager, il est
+                impossible de lancer des récupérations de données en masse par des
+                traitements non lancés par l'usager.
+              </p>
+            </li>
+          </ul>
+        </div>
+
+      </div>
       <form>
         <div class="row">
           <div class="col-md-10 col-md-offset-1">

--- a/front/src/features/landingPage/registration.html
+++ b/front/src/features/landingPage/registration.html
@@ -77,18 +77,17 @@
               Vos droits
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading">Afficher les données brutes à l'agent instructeur</h4>
+              <h4 class="list-group-item-heading">Afficher des données retravaillées à l’usager</h4>
               <p class="list-group-item-text">
-                L'agent du service instructeur, étant assermenté, peut voir les
-                informations personnelles
+                Il est possible d'afficher des données à l’usager, si elles ne
+                menacent pas sa vie privée par exemple, les tarifs de la cantine
+                après avoir été calculés à partir du quotient familial récupéré
+                auprès de la CAF.
               </p>
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading">Afficher les données après traitement à l'usager</h4>
+              <h4 class="list-group-item-heading"> Inventer des services innovants avec l’API</h4>
               <p class="list-group-item-text">
-                Il est possible d'afficher des données si elles ont été modifiées,
-                par exemple, les tarifs de la cantine après avoir été calculés à
-                partir du quotient familial récupéré auprès de la CAF
               </p>
             </li>
           </ul>
@@ -102,12 +101,19 @@
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Accepter la charte</h4>
               <p class="list-group-item-text">
-                Il n'est pas nécessaire de la faire signer. Obtenir le jeton
-                vous engage à respecter la charte.
+                Cette charte vous donne droit à un jeton d'accès à l'API
+                Particulier pour récupérer des données fiables utiles à
+                vos démarches.
               </p>
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading">Récupérer l'accord de l'usager</h4>
+              <h4 class="list-group-item-heading">Traiter la bonne donnée par le bon agent</h4>
+              <p class="list-group-item-text">L'agent habilité du service
+                instructeur peut accéder aux données personnelles
+              </p>
+            </li>
+            <li class="list-group-item">
+              <h4 class="list-group-item-heading">Informer correctement l’usager</h4>
               <p class="list-group-item-text">Explicitement demander l'accord de
                 l'usager pour récupérer ses données auprès d'un fournisseur.
               </p>
@@ -121,19 +127,18 @@
               Les interdits
             </li>
             <li class="list-group-item">
-              <h4 class="list-group-item-heading">Afficher les données brutes à l'usager</h4>
+              <h4 class="list-group-item-heading"> Afficher des données confidentielles à l’usager</h4>
               <p class="list-group-item-text">
-                API Particulier ne permet pas d'identifier la personne, vous n'afficherez
-                pas d'informations personnelles à l'usager car il peut s'agir
-                des données d'un autre.
+                L’usager n’étant pas authentifié, aucune garantie ne vous permet
+                d’afficher des donnée liées à la vie privée sans prendre le
+                risque de les dévoiler à un tiers.
               </p>
             </li>
             <li class="list-group-item">
               <h4 class="list-group-item-heading">Recupérer les informations par lot</h4>
               <p class="list-group-item-text">
-                Ne pouvant pas récupérer l'accord explicite de l'usager, il est
-                impossible de lancer des récupérations de données en masse par des
-                traitements non lancés par l'usager.
+                L’API Particulier propose du point à point, vous ne pouvez lancer
+                des récupérations de données en masse.
               </p>
             </li>
           </ul>


### PR DESCRIPTION
Ajout d'une traduction de la charte en se basant sur [tldrlegal](https://www.tldrlegal.com/l/apache2)

Le rendu ressemble à ça ?
![charte](https://cloud.githubusercontent.com/assets/5861569/12888391/297178da-ce7a-11e5-9b72-60cbe2ba7193.png)

Vous pouvez vous rendre sur la [page d'inscription](https://apiparticulier-dev.sgmap.fr/#/registration) pour voir le rendu complet. 

Vous en pensez quoi ?